### PR TITLE
Fix GHCJS resolver name in "Invalid resolver value" error message

### DIFF
--- a/src/Stack/Types/Config.hs
+++ b/src/Stack/Types/Config.hs
@@ -679,7 +679,7 @@ instance Show ConfigException where
     show (ParseResolverException t) = concat
         [ "Invalid resolver value: "
         , T.unpack t
-        , ". Possible valid values include lts-2.12, nightly-YYYY-MM-DD, ghc-7.10.2, and ghcjs-0.1.0-ghc-7.10.2. "
+        , ". Possible valid values include lts-2.12, nightly-YYYY-MM-DD, ghc-7.10.2, and ghcjs-0.1.0_ghc-7.10.2. "
         , "See https://www.stackage.org/snapshots for a complete list."
         ]
     show (NoProjectConfigFound dir mcmd) = concat


### PR DESCRIPTION
When stack cannot parse the `resolver` field in `stack.yaml`, it currently prints the following error message:

> Could not parse '/Users/romac/Code/stack-resolver-bug/stack.yaml':
AesonException "failed to parse field 'resolver': Invalid resolver value: **ghcjs-0.1.0-ghc-7.10.2**. Possible valid values include lts-2.12, nightly-YYYY-MM-DD, ghc-7.10.2, and **ghcjs-0.1.0-ghc-7.10.2**. See https://www.stackage.org/snapshots for a complete list."
See https://github.com/commercialhaskell/stack/wiki/stack.yaml.

The message incorrectly mentions that `ghcjs-0.1.0-ghc-7.10.2` is a valid resolver name, when the correct one is `ghcjs-0.1.0_ghc-7.10.2`, as [advertised on the wiki](https://github.com/commercialhaskell/stack/wiki/stack.yaml).